### PR TITLE
New Docker Compose file & added X11 authentication compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 services:
   - docker
 
-install:
-  - docker build -t ws-cef .
-  # - docker run -it ws-cef bash
+before_script:
+  - docker-compose build
 
-scripts:
-  - docker ps -a | grep -q ws-cef
+script:
+  - docker-compose run wscef

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,12 @@ LABEL maintainer "Fabio Rodrigues Ribeiro <farribeiro@gmail.com>"
 RUN apt-get update \
 	&& apt-get upgrade -y \
 	&& apt-get install -y \
+	language-pack-pt \
 	openssl \
 	libnss3-tools \
 	firefox \
 	firefox-locale-pt \
+	xauth \
 	--no-install-recommends \
 	# firefox -CreateProfile default
 	&& apt-get purge --auto-remove -y \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  wscef:
+    build: .
+    devices:
+      - /dev/snd:/dev/snd
+    environment:
+      - DISPLAY=${DISPLAY}
+      - XAUTHORITY=/home/ff/.Xauthority
+      - HOST_HOSTNAME=${HOSTNAME}
+    cpuset: '0'
+    mem_limit: 512M
+    restart: 'on-failure:1'
+    volumes:
+      - /dev/shm:/dev/shm
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ${XAUTHORITY}:/tmp/.docker.xauth:ro

--- a/startup.sh
+++ b/startup.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
 
-su -c "apt-get update \
-  && apt-get upgrade -y"
+export LANG="pt_BR.UTF-8"
 
-if [ ! -d $HOME/.mozilla ]
+if [ -n "${XAUTHORITY}" ] && [ -n "${HOST_HOSTNAME}" ]
+then
+  if [ "${HOSTNAME}" != "${HOST_HOSTNAME}" ]
+  then
+    [ -f ${XAUTHORITY} ] || touch ${XAUTHORITY}
+    xauth add ${HOSTNAME}/unix${DISPLAY} . \
+    $(xauth -f /tmp/.docker.xauth list ${HOST_HOSTNAME}/unix${DISPLAY} | awk '{ print $NF }')
+  else
+    cp /tmp/.docker.xauth ${XAUTHORITY}
+  fi
+fi
+
+if [ ! -d ~/.mozilla ]
 then
   firefox -CreateProfile default \
-  && su -c "apt -y install /src/GBPCEFwr64.deb" \
+  && su -c "apt update && apt -y upgrade && apt -y install /src/GBPCEFwr64.deb" \
   && exit 3
 else
   su -c "/etc/init.d/warsaw start" \


### PR DESCRIPTION
We include a Docker Compose file to make it easier to build and run the container. Execute `docker-compose build` to build the container and `docker-compose run wscef` to run it.

We also include X11 authentication compatibility in startup script. With these changes, one can surely start Firefox from the container if host system requires X11 authentication (if it doesn't, just drop variables `XAUTHORITY` and/or `HOST_HOSTNAME` from `environment` section of Docker Compose file.

We ensure startup script will work whether the container is running in host mode or not. In order to enable host mode in the container, just add `network_mode: 'host'` to `wscef` section of Docker Compose file (equivalent to `--net=host` option of `docker` command).