### PR TITLE
Install GBPCEFwr64.deb in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
 
 
 ADD https://cloud.gastecnologia.com.br/cef/warsaw/install/GBPCEFwr64.deb /src/
+RUN apt -y install /src/GBPCEFwr64.deb
 COPY startup.sh /home/ff/
 
 # Add ff  user

--- a/startup.sh
+++ b/startup.sh
@@ -16,8 +16,7 @@ fi
 
 if [ ! -d ~/.mozilla ]
 then
-  firefox -CreateProfile default \
-  && su -c "apt update && apt -y upgrade && apt -y install /src/GBPCEFwr64.deb"
+  firefox -CreateProfile default
 else
   su -c "/etc/init.d/warsaw start"
 fi


### PR DESCRIPTION
Every time the container is run, GBPCEFwr64.deb is installed. Thus for performance reasons it is better to install GBPCEFwr64.deb in Dockerfile instead of to do it in startup.sh.