### PR TITLE
Setup locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,18 @@ LABEL maintainer "Fabio Rodrigues Ribeiro <farribeiro@gmail.com>"
 ENV USER=ff
 ENV GUID=1000
 
+# Setup locale
+ENV LANGUAGE pt_BR.UTF-8
+ENV LANG pt_BR.UTF-8
+ENV LC_ALL pt_BR.UTF-8
+RUN apt-get update && apt-get install -y locales \
+	&& localedef -i pt_BR -c -f UTF-8 -A /usr/share/locale/locale.alias pt_BR.UTF-8
+
+
 COPY startup.sh /home/ff/
 
 # Install Firefox
-RUN apt-get update \
-	&& apt-get upgrade -y \
+RUN apt-get upgrade -y \
 	&& apt-get install -y \
 	ca-certificates \
 	wget \


### PR DESCRIPTION
Estava dando esse erro e não conseguia instalar o warsaw:

	Setting up warsaw (1.12.13-8) ...
	Traceback (most recent call last):
	  File "/usr/bin/warsaw", line 706, in <module>
		ret = main(sys.argv)
	  File "/usr/bin/warsaw", line 700, in main
		locale.setlocale(locale.LC_ALL, '')
	  File "/usr/lib/python2.7/locale.py", line 581, in setlocale
		return _setlocale(category, locale)
	locale.Error: unsupported locale setting

Depois de quebrar um pouco a cabeça percebi que era problema no locale.
Segui mais ou menos o que está aqui: https://hub.docker.com/_/debian#locales