### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,4 @@ Be aware some installations may run another display server, such as Wayland.~~
 
 The latest firefox release support wayland, not tested with xauth
 
-**PS:** The root password is **wscef** by https://github.com/farribeiro/wscef-docker/issues/29
-
 [1] https://github.com/jsalatiel/wsbb-docker/commit/72e42bb5f04fbe8eb1f7f3e6226975aba137dcb5#diff-3254677a7917c6c01f55212f86c57fbf

--- a/startup.sh
+++ b/startup.sh
@@ -9,5 +9,4 @@ runx xauth add ${HOSTNAME}/unix${DISPLAY} . $(runx xauth list | awk '$1 !~ /loca
 runx xauth generate $DISPLAY . untrusted timeout 0
 
 /usr/local/bin/warsaw/core \
-&& runx firefox -no-remote -CreateProfile default \
 && runx firefox -no-remote -private-window --class CaixaEconomica --name CaixaEconomica https://www.caixa.gov.br


### PR DESCRIPTION
A forma de uso permanece a mesma, mas não há mais senha para o usuário root.

Removi a criação antecipada do perfil no firefox.

Problemas:
1) A instalação do warsaw verifica a existência de systemd no sistema, e o firefox-esr traz o pacote como dependência indireta. Por isso a criação prévia do diretório do firefox (no meu entendimento da nossa conversa) não resolve. Ignorar o erro da instalação não é ideal, por outro lado não consegui que o systemd não seja instalado.
 2) Na imagem que construí hoje o warsaw não executa. Ou seja, nem consigo mais usar o container. Tenho uma imagem criada há 7 dias, que funciona. Warsaw teve nova versão liberada neste meio tempo?
```
wscef    | System has not been booted with systemd as init system (PID 1). Can't operate.
wscef    | Failed to connect to bus: Host is down
```

@farribeiro tem alguma ideia especialmente sobre este segundo ponto? Acredito que tu testou com sucesso a PR anterior.