### PR TITLE
Nozy space fix at Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Run Warsaw in a container
 
 # Base docker image
-FROM debian: bookworm-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer "Fabio Rodrigues Ribeiro <farribeiro@gmail.com>"
 


### PR DESCRIPTION
Hello!

I noticed a small typo about a space separating image tag. This PR is a fix - instead just opening a issue to this.